### PR TITLE
docs: add instructions for cleaning up stale branches

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -333,6 +333,14 @@ aid cleanup
 aid cleanup --force
 ```
 
+### Clean Up Stale Branches
+
+After merging PRs, remote branches are deleted but local tracking references may remain. To clean them up:
+
+```bash
+git fetch --prune
+```
+
 ---
 
 ## Environment Variables


### PR DESCRIPTION
## Summary
Adds documentation for cleaning up stale branch references after merging PRs.

## Changes
- Added "Clean Up Stale Branches" section to usage guide
- Documents `git fetch --prune` command to remove stale remote tracking references