### PR TITLE
fix: BSD sed compatibility for macOS in extract_repo_path

### DIFF
--- a/scripts/ai-dispatch.sh
+++ b/scripts/ai-dispatch.sh
@@ -110,7 +110,7 @@ extract_issue_number() {
 # Extract owner/repo from GitHub URL (works for both issues and PRs)
 extract_repo_path() {
     local url="$1"
-    echo "$url" | sed -E 's|https?://github\.com/([^/]+/[^/]+)/(issues|pull)/[0-9]+.*|\1|'
+    echo "$url" | sed -E 's|https?://github\.com/([^/]+/[^/]+)/[^/]+/[0-9]+.*|\1|'
 }
 
 # Get the current repository's GitHub owner/repo path


### PR DESCRIPTION
## Summary

Fixes `aid review <pr-url>` crashing on macOS with a `sed` RE error.

## Changes

- Replace `(issues|pull)` alternation group with `[^/]+` in the `extract_repo_path` sed pattern

## Root Cause

macOS ships with BSD `sed`, which does not support alternation (`|`) inside capture groups in extended regex mode (`-E`). The pattern `(issues|pull)` triggered:

```
sed: 1: "s|https?://github\.com/ ...": RE error: parentheses not balanced
```

Since the `(issues|pull)` group was never captured (only `\1` = `owner/repo` was used), replacing it with `[^/]+` is functionally identical and works on both macOS BSD `sed` and GNU `sed`.

## Related Issues

Fixes `aid review https://github.com/iyioon/aid/pull/8` failing with repository validation error.