### PR TITLE
fix(dispatch): handle interactive mode in agent system prompt

### DIFF
--- a/agents/dispatch.md
+++ b/agents/dispatch.md
@@ -114,4 +114,8 @@ If you encounter issues:
 3. If blocked, include the blocker in the PR description
 4. Never leave the codebase in a broken state
 
-Begin working on the assigned task now. Be thorough, be careful, and deliver quality work.
+## Starting a Session
+
+**If a task has been provided** (e.g. in the initial prompt): begin working on it immediately and autonomously. Complete the entire workflow — implementation, commits, and PR creation — without stopping to ask unless genuinely blocked.
+
+**If no task has been provided yet** (interactive mode): ask the user clearly and concisely: *"What would you like me to work on?"* Once they describe the task, execute the full workflow autonomously through to PR creation. Do not stop after implementation.


### PR DESCRIPTION
## Summary

When `aid` is run with no arguments (interactive mode), the AI eventually doesn't create a pull request. This fixes the root cause in the agent system prompt — the correct layer for this logic.

## Root Cause Analysis

The closing line of `dispatch.md` was:

> *"Begin working on the assigned task now."*

This works fine when `aid "my task"` is used — the task is injected via `--prompt` as the first message, and the agent immediately executes the full workflow.

But in **interactive mode** (`aid` with no args), OpenCode launches with just `--agent dispatch` and no `--prompt`. The user types their task as a freeform chat message. The agent has no system-level instruction for this scenario, so it defaults to **conversational behaviour** — it helps with the task but never frames the session as an autonomous workflow that must end with a PR.

### Why not fix this in the shell script with `--prompt`?

The first attempt was to inject a meta-instruction via `--prompt` in `interactive_dispatch()`. That was reverted after checking the OpenCode docs and AI prompting literature:

- Per the [OpenCode docs](https://opencode.ai/docs/cli/), `--prompt` seeds the **first user message** in the conversation, not the system prompt
- Injecting context-setting instructions as a *user message* is a known prompting antipattern — the model receives them in the wrong role, weakening their effect
- [Anthropic's agent-building guide](https://www.anthropic.com/research/building-effective-agents) emphasises: *"Maintain simplicity in your agent's design"* — layering shell-script prompt injection on top of an agent system prompt adds fragile complexity

The [OpenCode agent docs](https://opencode.ai/docs/agents/#prompt) confirm the right place for persistent instructions is the agent's markdown system prompt, not injected chat messages.

## Changes

- `agents/dispatch.md`: Replace the unconditional `"Begin working on the assigned task now."` closing line with a `## Starting a Session` section that explicitly handles both modes:
  - **Task provided** → execute immediately and autonomously, end with PR
  - **No task yet** (interactive) → ask once, then execute the full workflow through PR creation

## Testing

No automated tests (prompt/agent behaviour). The fix mirrors how well-designed agent system prompts handle mode-awareness — by putting the conditional logic in the system prompt where it has full effect, rather than injecting it via `--prompt` where it arrives as a weaker user-turn message.

## Related Issues

N/A