### PR TITLE
docs: address PR #8 review feedback on installation and branch naming

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,16 +91,18 @@ This allows OpenCode to work in the worktrees directory.
 
 ## Branch Naming
 
-Default patterns:
-- GitHub issues: `aid/issue-<number>`
-- Plain text: `aid/task-<sanitized>-<timestamp>`
+The system uses a unique session ID for all branches to avoid collisions.
 
-To change the prefix, edit the script:
+Format: `aid/<YYYYMMDD-HHMMSS-PID>`
+Example: `aid/20250312-143022-1234`
+
+The worktree directory also uses this session ID.
+
+To change the prefix, edit `~/.config/opencode/scripts/ai-dispatch.sh`:
 
 ```bash
-# Find these lines and change "aid/" to your preferred prefix
-branch_name="aid/issue-${issue_number}"
-branch_name="aid/task-${sanitized}-$(date +%H%M%S)"
+# Find this line and change "aid/" to your preferred prefix
+branch_name="aid/${session_id}"
 ```
 
 ## Target Branch for PRs
@@ -116,8 +118,8 @@ Session state is stored in JSON:
 ```json
 {
   "session_id": "20250312-143022-1234",
-  "branch_name": "aid/issue-123",
-  "worktree_path": "/Users/you/.config/opencode/worktrees/aid-issue-123",
+  "branch_name": "aid/20250312-143022-1234",
+  "worktree_path": "/Users/you/.config/opencode/worktrees/20250312-143022-1234",
   "task_type": "github_issue",
   "task_source": "https://github.com/owner/repo/issues/123",
   "task_description": "...",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,22 +30,26 @@ Before installing aid, ensure you have:
 
 ## Installation Steps
 
-### 1. Files are already in place
+### 1. Clone the Repository
 
-If you're reading this, the installation has already created:
-- `~/.config/opencode/scripts/ai-dispatch.sh`
-- `~/.config/opencode/agents/dispatch.md`
-- `~/.config/opencode/commands/*.md`
+> **⚠️ Warning**: Cloning into `~/.config/opencode` will overwrite any existing OpenCode configuration. If you already have one, back it up first:
+> ```bash
+> cp -r ~/.config/opencode ~/.config/opencode.bak
+> ```
+
+Clone this repository directly into your OpenCode configuration directory:
+
+```bash
+# Ensure the directory exists
+mkdir -p ~/.config/opencode
+
+# Clone the repository
+git clone https://github.com/iyioon/aid.git ~/.config/opencode
+```
 
 ### 2. Create the symlink
 
-The symlink to `~/.local/bin/aid` should already be created. Verify with:
-
-```bash
-which aid
-```
-
-If not found, create it manually:
+Create a symlink to make the `aid` command available globally:
 
 ```bash
 mkdir -p ~/.local/bin
@@ -98,6 +102,7 @@ rm ~/.local/bin/aid
 rm -rf ~/.config/opencode/scripts
 rm -rf ~/.config/opencode/agents
 rm -rf ~/.config/opencode/commands
+rm -rf ~/.config/opencode/skills
 rm -rf ~/.config/opencode/dispatch
 rm -rf ~/.config/opencode/worktrees
 rm -rf ~/.config/opencode/docs

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,12 +47,13 @@ aid https://github.com/owner/repo/issues/123
 
 The tool will:
 1. Fetch the issue title and description
-2. Create a branch named `aid/issue-123`
-3. Set up a worktree in `~/.config/opencode/worktrees/aid-issue-123`
-4. Work on the task automatically
-5. Create commits as it progresses
-6. Review the changes
-7. Create a PR against the main branch
+2. Create a unique session ID (e.g., `20250312-143022-1234`)
+3. Create a branch named `aid/20250312-143022-1234`
+4. Set up a worktree in `~/.config/opencode/worktrees/20250312-143022-1234`
+5. Work on the task automatically
+6. Create commits as it progresses
+7. Review the changes
+8. Create a PR against the main branch
 
 ### Working on a GitHub PR
 
@@ -63,9 +64,9 @@ aid https://github.com/owner/repo/pull/456
 
 The agent will:
 1. Fetch the PR details and review comments
-2. Create a branch named `aid/pr-456`
+2. Create a branch named `aid/20250312-143022-5678` (using a unique session ID)
 3. Implement the requested changes
-4. Push commits to the PR branch
+4. Push commits to a new session branch (`aid/<session-id>`) referencing the original PR
 
 ### Working on a Plain Text Task
 
@@ -249,8 +250,8 @@ Active Development Sessions
 ───────────────────────────────────────────────────────────────────────────────────────
 SESSION              STATUS       BRANCH                              CREATED
 ───────────────────────────────────────────────────────────────────────────────────────
-20250312-143022-1234 running      aid/issue-123                       2025-03-12T14:30:22Z
-20250312-150145-5678 completed    aid/task-add-dark-mode-150145       2025-03-12T15:01:45Z
+20250312-143022-1234 running      aid/20250312-143022-1234            2025-03-12T14:30:22Z
+20250312-150145-5678 completed    aid/20250312-150145-5678            2025-03-12T15:01:45Z
 ───────────────────────────────────────────────────────────────────────────────────────
 Total: 2 session(s)
 ```
@@ -280,8 +281,8 @@ Session: 20250312-143022-1234
 Status:        running
 Created:       2025-03-12T14:30:22Z
 Type:          github_issue
-Branch:        aid/issue-123
-Worktree:      /Users/you/.config/opencode/worktrees/aid-issue-123
+Branch:        aid/20250312-143022-1234
+Worktree:      /Users/you/.config/opencode/worktrees/20250312-143022-1234
 
 Task Description
 ─────────────────────────────────────────────
@@ -345,12 +346,12 @@ AID_DEBUG=1 aid review https://github.com/owner/repo/pull/123
    - For GitHub issues/PRs, fetches details via `gh` CLI
 
 2. **Branch Creation**
-   - GitHub issues: `aid/issue-<number>`
-   - GitHub PRs: `aid/pr-<number>`
-   - Plain text: `aid/task-<sanitized-description>-<timestamp>`
+   - Uses a unique session ID for branch naming
+   - Format: `aid/<timestamp>-<pid>`
+   - Example: `aid/20250312-143022-1234`
 
 3. **Worktree Setup**
-   - Creates worktree in `~/.config/opencode/worktrees/`
+   - Creates worktree in `~/.config/opencode/worktrees/<session-id>`
    - Based on latest `origin/main` (or `origin/master`)
 
 4. **State Tracking**


### PR DESCRIPTION
## Summary

Addresses the review feedback from PR #8 (docs: clarify installation steps and update branch naming).

## Changes

- **`docs/installation.md`**:
  - Elevated the destructive overwrite warning to appear *before* the `git clone` command, so users see it before running a command that could wipe their OpenCode config. Added backup instructions (`cp -r ~/.config/opencode ~/.config/opencode.bak`) as part of the warning.
  - Updated clone URL from `yourusername/aid` placeholder to the actual repo `iyioon/aid`.
  - Added `rm -rf ~/.config/opencode/skills` to the uninstall steps (was missing from the directory list).

- **`docs/usage.md`**:
  - Updated the `aid list` output example to show the actual `aid/<session-id>` branch format (was showing old `aid/issue-123` and `aid/task-add-dark-mode-150145`).
  - Updated the `aid view` output example (Branch and Worktree fields) to match the real naming convention.
  - Fixed PR workflow step 3 from the misleading "Push commits to the PR branch" to "Push commits to a new session branch (`aid/<session-id>`) referencing the original PR".
  - Updated the Branch Creation section in Workflow Details to accurately describe the session-ID-based naming.
  - Updated the Worktree Setup section to show `~/.config/opencode/worktrees/<session-id>`.

- **`docs/configuration.md`**:
  - Replaced old multi-pattern branch naming docs with accurate session-ID-based format description.
  - Corrected the State File Format JSON example to use `aid/20250312-143022-1234` branch name and `20250312-143022-1234` worktree path.

## Related Issues

Addresses review comments on #8