### PR TITLE
docs: add configuration reference and audit all docs against codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The `aid review` command enables a human-in-the-loop workflow for AI-generated P
 
 | Command | Mode | Creates Worktree | Edits Files | Posts Comment |
 |---------|------|------------------|-------------|---------------|
-| `aid review <pr-url>` | Read-only | No | No | Yes |
+| `aid review <pr-url>` | Read-only | Yes (detached, for code exploration) | No | Yes |
 | `aid <pr-url>` | Full access | Yes | Yes | Creates commits |
 
 ## Documentation
@@ -96,9 +96,10 @@ The `aid review` command enables a human-in-the-loop workflow for AI-generated P
 ### PR Review (`aid review <pr-url>`)
 
 1. **Fetch PR**: Gets PR details, diff, comments, and existing reviews
-2. **Run OpenCode**: Launches OpenCode with read-only `review` agent (TUI by default)
-3. **Analyze**: Agent reviews code for issues, bugs, and improvements
-4. **Post Comment**: Agent posts review comment via `gh pr review`
+2. **Create Worktree**: Creates a detached-HEAD worktree at the PR's head (for `git grep`/`git show` access); fork PRs fall back to the source repo
+3. **Run OpenCode**: Launches OpenCode with read-only `review` agent
+4. **Analyze**: Agent reviews code for issues, bugs, and improvements
+5. **Post Comment**: Agent posts review comment via `gh pr review`
 
 ## Agents
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,78 +4,204 @@
 
 | Path | Purpose |
 |------|---------|
-| `~/.config/opencode/scripts/` | Script files including aid.sh |
-| `~/.config/opencode/agents/` | Agent definitions (dispatch.md) |
-| `~/.config/opencode/commands/` | Custom commands |
+| `~/.config/opencode/scripts/` | Script files including `aid.sh` |
+| `~/.config/opencode/agents/` | Agent definitions (`dispatch.md`, `review.md`) |
+| `~/.config/opencode/commands/` | Custom slash commands |
 | `~/.config/opencode/dispatch/` | Session state files (JSON) |
 | `~/.config/opencode/worktrees/` | Git worktrees for tasks |
+| `~/.config/opencode/opencode.json` | OpenCode global configuration |
 
-## Customizing the Development Agent
+---
 
-Edit `~/.config/opencode/agents/dispatch.md` to customize the agent behavior.
+## Configuration Reference
 
-### Change the Model
+This section documents every tunable in `aid` — what it controls, where to change it, its current default, and when you'd want to change it.
+
+### Model
+
+**File:** `~/.config/opencode/opencode.json` → `model`  
+**Default:** `github-copilot/claude-sonnet-4.6`  
+**Change when:** You want to use a different model for all sessions (e.g. a more capable model for harder tasks, or a faster/cheaper model for routine work).
+
+```json
+{
+  "model": "github-copilot/claude-sonnet-4.6"
+}
+```
+
+Available models depend on your OpenCode installation and provider configuration.
+
+---
+
+### Agent Temperature
+
+**File:** `~/.config/opencode/agents/dispatch.md` and `~/.config/opencode/agents/review.md` → `temperature` (YAML frontmatter)  
+**Default:** `0.3` (both agents)  
+**Change when:** You want more creative/varied output (raise toward 0.8) or more deterministic/focused output (lower toward 0.1).
 
 ```yaml
 ---
-model: github-copilot/claude-sonnet-4  # Change this
 temperature: 0.3
 ---
 ```
 
-Available models depend on your OpenCode configuration.
+Each agent has its own temperature setting. Edit each file separately if you want them to differ.
 
-### Adjust Temperature
-
-- Lower (0.1-0.3): More focused, deterministic responses
-- Higher (0.5-0.8): More creative, varied approaches
-
-```yaml
 ---
-temperature: 0.5  # More creative
+
+### Agent System Prompt (Personality / Workflow)
+
+**File:** `~/.config/opencode/agents/dispatch.md` (dispatch agent) and `~/.config/opencode/agents/review.md` (review agent) — the body of each file (below the YAML frontmatter)  
+**Change when:** You want to change how the agent reasons, its workflow phases, commit message style, PR format, or output format.
+
+- **Dispatch agent** (`dispatch.md`): Controls the 5-phase development workflow (Understand → Plan → Implement → Review → PR), commit conventions, and PR description template.
+- **Review agent** (`review.md`): Controls review principles, severity levels, what to look for, and the exact format of the posted review comment.
+
 ---
+
+### Runtime Prompts (Task Context Passed to the Agent)
+
+**File:** `~/.config/opencode/scripts/aid.sh`  
+**Change when:** You want to change what context or framing is passed to the agent at the start of each run.
+
+There are two runtime prompts built by the script:
+
+**Dispatch prompt** (`dispatch()` function, around line 841):
+```bash
+task_prompt="## Task
+
+${task_description}
+
+## Context
+
+- Worktree: ${worktree_path}
+- Target branch: ${default_branch}${extra_context}"
 ```
+This prompt is passed via `--prompt` to `opencode --agent dispatch`.
 
-### Modify Permissions
+**Review prompt** (`review_pr()` function, around line 596):
+```bash
+review_prompt="Review PR #${pr_number}: ${pr_url}
 
-The default permissions allow full autonomy:
+Title: ${pr_title}
+Author: ${pr_author}
+Changes: +${pr_additions}/-${pr_deletions} lines
 
+## Description
+...
+## Prior Comments
+...
+## Prior Reviews
+...
+## Diff
+..."
+```
+This prompt is passed via `--prompt` to `opencode --agent review`.
+
+---
+
+### Agent Bash Permissions
+
+**File:** `~/.config/opencode/agents/dispatch.md` and `~/.config/opencode/agents/review.md` → `permission.bash` block (YAML frontmatter)  
+**Change when:** You want to restrict (or expand) what shell commands the agent is allowed to run without approval.
+
+**Dispatch agent** (full bash access):
 ```yaml
 permission:
   edit: allow
   bash:
     "*": allow
-    "git push *": allow
-    "gh pr create *": allow
+  webfetch: allow
 ```
 
-To require approval for certain operations:
+**Review agent** (read-only bash access):
+```yaml
+permission:
+  bash:
+    "*": deny
+    "git status*": allow
+    "git diff*": allow
+    "git log*": allow
+    "git show*": allow
+    "git grep*": allow
+    "gh pr view*": allow
+    "gh pr diff*": allow
+    "gh pr review*": allow
+    "gh api repos/*/pulls/*": allow
+```
 
+To require approval for specific dispatch agent commands (e.g. force push):
 ```yaml
 permission:
   edit: allow
   bash:
     "*": allow
-    "git push *": ask        # Ask before pushing
-    "rm -rf *": deny         # Never allow rm -rf
+    "git push --force*": ask   # Ask before force pushing
+    "rm -rf *": deny           # Never allow rm -rf
 ```
 
-## Custom Commands
+---
 
-The development workflow uses three commands:
+### Review Agent Tool Restrictions
 
-### /work-task
-Starts working on the assigned task. Edit `~/.config/opencode/commands/work-task.md`.
+**File:** `~/.config/opencode/agents/review.md` → `tools` block (YAML frontmatter)  
+**Default:** All write/edit tools disabled  
+**Change when:** You need to allow the review agent additional capabilities (not recommended — review is intentionally read-only).
 
-### /review-work
-Reviews changes before PR. Edit `~/.config/opencode/commands/review-work.md`.
+```yaml
+tools:
+  edit: false
+  write: false
+  patch: false
+  multiedit: false
+```
 
-### /create-pr
-Creates the pull request. Edit `~/.config/opencode/commands/create-pr.md`.
+---
 
-## OpenCode Global Config
+### MCP Servers
 
-The `opencode.json` includes:
+**File:** `~/.config/opencode/opencode.json` → `mcp`  
+**Change when:** You want to add, remove, or reconfigure MCP (Model Context Protocol) tool servers available to the agents.
+
+Current MCP servers:
+
+```json
+{
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
+      },
+      "enabled": true
+    },
+    "gh_grep": {
+      "type": "remote",
+      "url": "https://mcp.grep.app",
+      "enabled": true
+    }
+  }
+}
+```
+
+- **context7**: Provides up-to-date library documentation. Requires `CONTEXT7_API_KEY` environment variable. Set `"enabled": false` to disable.
+- **gh_grep**: Provides GitHub code search. No API key required.
+
+To disable an MCP server without removing it:
+```json
+"context7": {
+  "enabled": false
+}
+```
+
+---
+
+### External Directory Permissions
+
+**File:** `~/.config/opencode/opencode.json` → `permission.external_directory`  
+**Default:** `~/.config/opencode/worktrees/**` is allowed  
+**Change when:** Your worktrees are stored in a different location, or you want to allow/restrict OpenCode from accessing other directories.
 
 ```json
 {
@@ -87,33 +213,79 @@ The `opencode.json` includes:
 }
 ```
 
-This allows OpenCode to work in the worktrees directory.
+This permission is required for OpenCode to read and write files inside the git worktrees that `aid` creates. If you change `WORKTREES_DIR` in `aid.sh`, update this to match.
 
-## Branch Naming
+---
 
-The system uses a unique session ID for all branches to avoid collisions.
+### Branch Naming
 
-Format: `aid/<YYYYMMDD-HHMMSS-PID>`
-Example: `aid/20250312-143022-1234`
-
-The worktree directory also uses this session ID.
-
-To change the prefix, edit `~/.config/opencode/scripts/aid.sh`:
+**File:** `~/.config/opencode/scripts/aid.sh` → `branch_name` variable in `dispatch()` and `interactive_dispatch()`  
+**Default format:** `aid/<YYYYMMDD-HHMMSS-PID>`  
+**Example:** `aid/20250312-143022-1234`  
+**Change when:** You prefer a different branch prefix or format.
 
 ```bash
-# Find this line and change "aid/" to your preferred prefix
+# Find and update this line in both dispatch() and interactive_dispatch():
 branch_name="aid/${session_id}"
 ```
 
-## Target Branch for PRs
+---
 
-By default, PRs are created against the default branch (usually `main` or `master`).
+### Session State Directory
 
-The script auto-detects this from `refs/remotes/origin/HEAD`.
+**File:** `~/.config/opencode/scripts/aid.sh` → `DISPATCH_DIR` constant  
+**Default:** `~/.config/opencode/dispatch/`  
+**Change when:** You want session state files stored elsewhere.
+
+```bash
+readonly DISPATCH_DIR="${OPENCODE_CONFIG_DIR}/dispatch"
+```
+
+---
+
+### Worktrees Directory
+
+**File:** `~/.config/opencode/scripts/aid.sh` → `WORKTREES_DIR` constant  
+**Default:** `~/.config/opencode/worktrees/`  
+**Change when:** You want worktrees created in a different location. If you change this, also update `permission.external_directory` in `opencode.json`.
+
+```bash
+readonly WORKTREES_DIR="${OPENCODE_CONFIG_DIR}/worktrees"
+```
+
+---
+
+### Target Branch for PRs
+
+By default, PRs are created against the repository's default branch (usually `main` or `master`).
+
+The script auto-detects this from `refs/remotes/origin/HEAD`:
+```bash
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+```
+
+If auto-detection fails, it falls back to `main`. This value is passed as context in the task prompt but the actual PR target is determined by the `gh pr create` command in the agent.
+
+---
+
+## Custom Commands
+
+Custom slash commands are defined in `~/.config/opencode/commands/`. Each file is a Markdown file with YAML frontmatter.
+
+| Command | File | Agent | Purpose |
+|---------|------|-------|---------|
+| `/work-task` | `commands/work-task.md` | dispatch | Analyze and begin working on a task |
+| `/review-work` | `commands/review-work.md` | dispatch | Self-review changes before PR |
+| `/create-pr` | `commands/create-pr.md` | dispatch | Create pull request for completed work |
+| `/review-pr` | `commands/review-pr.md` | review | Review a PR and post feedback |
+
+To customize a command, edit the body of the corresponding `.md` file.
+
+---
 
 ## State File Format
 
-Session state is stored in JSON:
+Session state is stored as JSON in `~/.config/opencode/dispatch/<session-id>.json`:
 
 ```json
 {
@@ -130,4 +302,6 @@ Session state is stored in JSON:
 }
 ```
 
-Status values: `running`, `completed`, `failed`, `orphaned`
+**Status values:** `running`, `completed`, `failed`, `orphaned`
+
+**Task type values:** `github_issue`, `github_pr`, `plain_text`, `interactive`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,7 +64,7 @@ aid https://github.com/owner/repo/pull/456
 
 The agent will:
 1. Fetch the PR details and review comments
-2. Create a branch named `aid/20250312-143022-5678` (using a unique session ID)
+2. Check out the PR's existing branch (not a new `aid/` branch, so commits go directly to the PR)
 3. Implement the requested changes
 4. Push commits to the PR branch
 
@@ -246,13 +246,13 @@ aid list
 
 Output:
 ```
-Active Development Sessions
-───────────────────────────────────────────────────────────────────────────────────────
+Active AI Dispatch Sessions
+────────────────────────────────────────────────────────────────────────────────────────
 SESSION              STATUS       BRANCH                              CREATED
-───────────────────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────────────────────
 20250312-143022-1234 running      aid/20250312-143022-1234            2025-03-12T14:30:22Z
 20250312-150145-5678 completed    aid/20250312-150145-5678            2025-03-12T15:01:45Z
-───────────────────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────────────────────
 Total: 2 session(s)
 ```
 
@@ -301,16 +301,28 @@ Pull Request
 Open session in OpenCode? [y/N]
 ```
 
-### Clean Up Orphaned Sessions
+### Clean Up Sessions
 
-If sessions weren't cleaned up properly (e.g., system crash):
+If sessions weren't cleaned up properly (e.g., system crash), use `aid cleanup`:
 
 ```bash
-# See orphaned sessions
+# List orphaned sessions (running but process died) — dry run, no changes
 aid cleanup
 
-# Force cleanup
+# Force remove orphaned sessions
 aid cleanup --force
+
+# List failed sessions
+aid cleanup --failed
+
+# Force remove failed sessions
+aid cleanup --failed --force
+
+# List all cleanable sessions (orphaned + failed)
+aid cleanup --all
+
+# Force remove all cleanable sessions
+aid cleanup --all --force
 ```
 
 ### Clean Up Stale Branches
@@ -352,7 +364,8 @@ AID_DEBUG=1 aid review https://github.com/owner/repo/pull/123
 
 3. **Worktree Setup**
    - Creates worktree in `~/.config/opencode/worktrees/<session-id>`
-   - Based on latest `origin/main` (or `origin/master`)
+   - For issues/plain text: based on latest `origin/<default-branch>`
+   - For GitHub PRs: checked out at the PR's existing branch (so commits go directly to the PR)
 
 4. **State Tracking**
    - Creates JSON state file in `~/.config/opencode/dispatch/`
@@ -370,17 +383,23 @@ AID_DEBUG=1 aid review https://github.com/owner/repo/pull/123
 ### What Happens During Review
 
 1. **PR Fetching**
-   - Fetches PR metadata (title, description, author)
+   - Fetches PR metadata (title, description, author, additions/deletions)
    - Retrieves full diff via `gh pr diff`
    - Loads existing comments and reviews for context
 
-2. **OpenCode Execution**
-   - Runs `opencode --agent review` with PR context
+2. **Worktree Setup** (non-fork PRs only)
+   - Fetches the PR branch from origin
+   - Creates a detached-HEAD worktree at the PR's head commit
+   - Allows the review agent to run `git grep` / `git show` against the exact code being reviewed
+   - For fork PRs, falls back to running from the source repo root (diff still provided as context)
+
+3. **OpenCode Execution**
+   - Runs `opencode --agent review` with enriched PR context (diff, description, prior comments/reviews)
    - Agent analyzes in read-only mode (cannot edit files)
 
-3. **Review Posting**
+4. **Review Posting**
    - Agent posts structured comment via `gh pr review`
-   - No worktree created, no cleanup needed
+   - Worktree is cleaned up after the session ends
 
 ### The Development Agent
 

--- a/scripts/aid.sh
+++ b/scripts/aid.sh
@@ -9,8 +9,11 @@
 #   aid "task description"           Work on a plain text task (TUI mode)
 #   aid review <pr-url>              Review a PR and post feedback (TUI mode, read-only)
 #   aid list                         List active dispatch sessions
+#   aid view <session-id>            View session details and optionally resume
 #   aid cleanup [--failed|--all] [--force]  Clean up sessions
 #   aid resume <session-id>          Resume a previous session
+#   aid help                         Show help message
+#   aid --version                    Show version information
 #
 # Environment:
 #   AID_DEBUG=1                      Enable debug output


### PR DESCRIPTION
## Summary

Resolves #17. Adds a complete Configuration Reference to `docs/configuration.md` and fixes every doc drift issue identified in the issue.

## Changes

### `docs/configuration.md` — new Configuration Reference section
- Documents all tunables with file location, default value, and guidance on when to change:
  - Model (`opencode.json` → `model`)
  - Agent temperature (agent frontmatter)
  - Agent system prompts (agent body)
  - Runtime prompts (exact variable names and line references in `aid.sh`)
  - Agent bash permissions (agent frontmatter)
  - Review agent tool restrictions (agent frontmatter)
  - MCP servers (`opencode.json` → `mcp`)
  - External directory permissions (`opencode.json` → `permission`)
  - Branch naming, session/worktree directories
- Fixes stale model ID: `claude-sonnet-4` → `claude-sonnet-4.6`
- Adds `review.md` to the agent customisation section (was missing)
- Documents all four custom commands in a table

### `docs/usage.md` — accuracy fixes
- Correct `aid list` output header: "Active Development Sessions" → "Active AI Dispatch Sessions" (matches actual code output)
- Add `--failed` and `--all` cleanup flags to the cleanup section (previously undocumented)
- Fix "Working on a GitHub PR" description: PR tasks use the PR's existing branch, not a new `aid/` branch
- Fix "What Happens During Review": review now creates a detached-HEAD worktree (added in #18); the old "No worktree created" text was wrong

### `README.md` — accuracy fixes
- Fix "Creates Worktree" column for `aid review`: was "No", now "Yes (detached, for code exploration)"
- Add step 2 "Create Worktree" to the PR Review workflow description

### `scripts/aid.sh` — header comment completeness
- Add missing `aid view <session-id>` command to the usage block
- Add missing `aid help` and `aid --version` commands to the usage block

## Testing

All changes are documentation-only (plus the `aid.sh` header comment). Verified each change against the actual code behaviour.