### PR TITLE
fix(dispatch): inject PR review comments and reviews into dispatch prompt

### DIFF
--- a/scripts/aid.sh
+++ b/scripts/aid.sh
@@ -998,6 +998,14 @@ Source: $input"
             else map("**\(.author.login)** [\(.state)]: \(.body)") | join("\n\n")
             end')
 
+        # Fetch inline review thread comments via REST API
+        local inline_comments_json inline_text
+        inline_comments_json=$(gh api "repos/${repo_path}/pulls/${pr_number}/comments" 2>/dev/null || echo "[]")
+        inline_text=$(echo "$inline_comments_json" | jq -r '
+            if length == 0 then "(none)"
+            else map("**\(.user.login)** on `\(.path)` line \(.original_line // .line // "?"):\n\(.body)") | join("\n\n")
+            end')
+
         task_description="GitHub PR #${pr_number}: ${pr_title}
 
 $(echo "$pr_json" | jq -r '.body // "No description provided"')
@@ -1010,6 +1018,9 @@ ${comments_text}
 
 ## Review Feedback
 ${reviews_text}
+
+## Inline Review Comments
+${inline_text}
 
 Source: $input
 


### PR DESCRIPTION
## Summary

Fixes #22. When `aid <pr-url>` is used to dispatch a fix for a PR, the review feedback (comments and review bodies) was never included in the agent's prompt — the agent was only told to "review the PR comments" but had no actual content to work from.

## Changes

- Added `comments,reviews` to the `--json` field list in the `gh pr view` call inside `dispatch()`
- Extracted and formatted both fields using the same `jq` patterns already used in `review_pr()`
- Embedded the formatted content as `## Review Comments` and `## Review Feedback` sections in `task_description`, before the closing instruction
- Replaced the vague "Review the PR comments and requested changes, then implement the necessary fixes." instruction with the more direct "Address the above review comments and requested changes."

## Acceptance Criteria

- [x] `--json` fetch in `dispatch()` includes `comments` and `reviews`
- [x] `task_description` contains a `## Review Comments` and `## Review Feedback` section populated from the fetched data
- [x] Empty comments/reviews degrade gracefully with `"(none)"` — no crashes or blank sections
- [x] Plain-text task dispatch (`aid "do something"`) is unaffected
- [x] Issue dispatch (`aid <issue-url>`) is unaffected