### PR TITLE
fix(review): clarify task matching with visible log message

### DIFF
--- a/scripts/aid.sh
+++ b/scripts/aid.sh
@@ -814,7 +814,9 @@ review_pr() {
         matched_task_id=$(find_task_by_pr "$pr_url" "$pr_branch_name" 2>/dev/null || echo "")
         if [[ -n "$matched_task_id" ]]; then
             task_context_block=$(build_task_context_block "$matched_task_id")
-            log_debug "Injecting task context for: $matched_task_id"
+            log_info "Found existing task: $matched_task_id"
+        else
+            log_debug "No existing task found for this PR (review will proceed without task context)"
         fi
     fi
 


### PR DESCRIPTION
## Summary

Addresses the user question: "When I do `aid <task>` and then `aid review <pr>` after it completes, why does it create two tasks in aid task list?"

**Finding:** `aid review <pr>` does NOT create duplicate tasks. The code is correct.

The multiple tasks users see are from stale tasks from previous `aid <task>` runs that weren't cleaned up.

## Changes

- Changed `log_debug` to `log_info` in `review_pr()` when an existing task is found
- Now shows: `[info] Found existing task: aid-xxx` (always visible)
- Added debug message when no task is found for context

## Root Cause Analysis

The `review_pr()` function:
1. Does NOT call `create_task_context()` 
2. Only calls `find_task_by_pr()` to match existing tasks by branch name
3. Creates a temporary worktree for review, then cleans it up

Tasks accumulate because:
- Each `aid <task>` creates a new session with unique timestamp
- `update_task_pr()` and `complete_task()` are TODOs, never called
- Users must run `aid tasks cleanup --merged --force` to clean up

## Testing

Run `aid review <pr-url>` and observe the new log message showing which existing task was matched.