### PR TITLE
fix(tasks): prevent SIGPIPE crash in tasks_list and tasks_cleanup

### DIFF
--- a/scripts/aid.sh
+++ b/scripts/aid.sh
@@ -1338,10 +1338,14 @@ tasks_list() {
         # If the task is not already marked done, query GitHub to get the real
         # state: branch gone means merged/closed; PR state provides more detail.
         if [[ "$status" != "done" && -n "$task_repo" && "$task_repo" != "null" ]]; then
-            local http_status="" pr_state=""
-            http_status=$(gh api --include \
-                "repos/${task_repo}/branches/${branch_name}" 2>/dev/null \
-                | grep -m1 '^HTTP/' | awk '{print $2}')
+            local http_status="" pr_state="" gh_raw=""
+            # Capture gh api output into a variable first to avoid SIGPIPE when
+            # piping directly into grep -m1 (gh api writes many lines; grep exits
+            # after the first match and closes the pipe, sending SIGPIPE to gh api,
+            # which — under set -o pipefail — kills the whole script).
+            gh_raw=$(gh api --include \
+                "repos/${task_repo}/branches/${branch_name}" 2>/dev/null || true)
+            http_status=$(printf '%s\n' "$gh_raw" | grep -m1 '^HTTP/' | awk '{print $2}')
 
             if [[ "$http_status" == "404" ]]; then
                 # Branch is gone — check if the PR was merged or just closed
@@ -1569,10 +1573,14 @@ tasks_cleanup() {
                     # distinguish a definitive 404 (branch gone) from transient
                     # failures (network error, rate-limit, auth expiry) that
                     # should NOT cause a destructive removal.
-                    local http_status
-                    http_status=$(gh api --include \
-                        "repos/${task_repo}/branches/${branch}" 2>/dev/null \
-                        | grep -m1 '^HTTP/' | awk '{print $2}')
+                    # Capture into a variable first to avoid SIGPIPE: gh api
+                    # outputs many lines; grep -m1 exits early and closes the
+                    # pipe, which under set -o pipefail kills the script.
+                    local gh_raw=""
+                    gh_raw=$(gh api --include \
+                        "repos/${task_repo}/branches/${branch}" 2>/dev/null || true)
+                    local http_status=""
+                    http_status=$(printf '%s\n' "$gh_raw" | grep -m1 '^HTTP/' | awk '{print $2}')
                     if [[ "$http_status" == "404" ]]; then
                         should_clean=true
                         reason="branch deleted/merged"


### PR DESCRIPTION
## Summary

`aid tasks list` and `aid tasks cleanup` were silently exiting with code 141 (SIGPIPE) before printing any output, making cleanup appear to do nothing.

## Root Cause

Under `set -o pipefail`, piping `gh api --include` directly into `grep -m1 '^HTTP/'` causes a SIGPIPE error:

```bash
# BROKEN: gh api outputs many header lines; grep exits after the first
# match and closes the pipe, sending SIGPIPE to gh api.
http_status=$(gh api --include "repos/.../branches/..." 2>/dev/null \
    | grep -m1 '^HTTP/' | awk '{print $2}')
```

`gh api` produces a large HTTP response (headers + JSON body). `grep -m1` finds the first `HTTP/` line and exits, closing the read end of the pipe. `gh api` then receives SIGPIPE when it tries to write further output. Under `set -o pipefail`, this SIGPIPE exit code propagates out of the `$()` subshell and kills the parent script — silently, before any output is printed.

## Fix

Capture `gh api` output into a bash variable first (no pipe involved), then pipe from the in-memory string to `grep`:

```bash
# FIXED: buffer full output first, then grep from memory (no SIGPIPE possible)
local gh_raw=""
gh_raw=$(gh api --include "repos/.../branches/..." 2>/dev/null || true)
http_status=$(printf '%s\n' "$gh_raw" | grep -m1 '^HTTP/' | awk '{print $2}')
```

The same pattern was present in both `tasks_list` and `tasks_cleanup` — both are fixed.

## Testing

- `aid tasks list` now correctly shows tasks with live GitHub status
- `aid tasks cleanup` now correctly identifies and lists merged tasks
- `aid tasks cleanup --merged --force` now removes merged task contexts