### PR TITLE
feat(aid): add 'pr' command to import existing PRs

### DIFF
--- a/scripts/aid.sh
+++ b/scripts/aid.sh
@@ -428,6 +428,13 @@ _import_pr() {
     require_cmd jq
     require_cmd git
 
+    # Ensure we're in a git repo
+    git rev-parse --git-dir &>/dev/null || die "Not in a git repository"
+
+    if ! is_github_pr_url "$input"; then
+        die "Invalid PR URL: $input"
+    fi
+
     log_info "Importing PR..."
 
     # Extract info
@@ -442,7 +449,7 @@ _import_pr() {
 
     local title body branch url state
     title=$(echo "$pr_json" | jq -r '.title')
-    body=$(echo "$pr_json" | jq -r '.body')
+    body=$(echo "$pr_json" | jq -r '.body // ""')
     branch=$(echo "$pr_json" | jq -r '.headRefName')
     url=$(echo "$pr_json" | jq -r '.url')
     state=$(echo "$pr_json" | jq -r '.state')
@@ -1034,6 +1041,7 @@ main() {
         *)
             # Check if it's a task ID or PR URL to resume
             if is_github_pr_url "$cmd"; then
+                local task_id
                 if task_id=$(find_task_by_pr "$cmd"); then
                     cmd_resume "$task_id"
                 else


### PR DESCRIPTION
## Summary
Adds a new `aid pr <URL>` command to import an existing GitHub PR as an aid task. This allows the AI to work on PRs that were created externally or to resume work on a PR if the local task data was lost.

## Changes
- Added `cmd_pr` function to `scripts/aid.sh`.
- Updated `main` to handle the `pr` command.
- Updated `cmd_help` to document the new command.
- The command fetches PR details, creates a worktree for the PR branch, creates a task record, and then resumes the task (which prompts the AI to address feedback if any).

## Testing
- Verified `aid pr <URL>` fails gracefully with invalid URLs or when PR details cannot be fetched.
- Verified `aid pr <URL>` detects if a task already exists for the PR and switches to `resume` mode.