### PR TITLE
feat(aid): include issue comments when fetching GitHub issues

### DIFF
--- a/scripts/aid.sh
+++ b/scripts/aid.sh
@@ -290,8 +290,15 @@ cmd_new() {
         issue_number=$(extract_number "$input")
 
         log_info "Fetching issue #${issue_number} from ${issue_repo}..."
-        issue_body=$(gh issue view "$issue_number" --repo "$issue_repo" --json title,body,number \
-            --jq '"Issue #" + (.number|tostring) + ": " + .title + "\n\n" + .body') || \
+        issue_body=$(gh issue view "$issue_number" --repo "$issue_repo" --json title,body,number,comments \
+            --jq '
+                "Issue #" + (.number|tostring) + ": " + .title + "\n\n" + (.body // "") +
+                ([.comments[] | select((.body // "") != "") |
+                    "Comment by " + (.author.login // "unknown") + ":\n" + .body
+                ] | if length > 0 then
+                    "\n\n--- Issue Comments ---\n\n" + join("\n\n---\n\n")
+                else "" end)
+            ') || \
             die "Failed to fetch issue"
         source="$issue_body"
         repo="$issue_repo"


### PR DESCRIPTION
## Summary
`aid new <issue-url>` now fetches and includes issue comments alongside the title and body, so the AI agent receives the full discussion context when starting work on an issue.

## Changes
- Added `comments` to the `gh issue view --json` fields in `cmd_new()`
- Appended non-empty comments under an `--- Issue Comments ---` section with author attribution
- Added null-safety guard on issue `.body` (matching the existing PR path pattern)
- Only shows the comments section when non-empty comments exist (filtered before length check)

## Testing
- Verified jq expression against all edge cases: normal comments, no comments, empty-body-only comments, null issue body, null/missing author
- Tested against real GitHub issue (`gh issue view 40 --repo iyioon/aid`)